### PR TITLE
FIX: Improve do_1_start.sh script and README.md

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -95,8 +95,7 @@ jobs:
             # Execute k8s creation
             terraform -chdir=terraform/digital_ocean/do_create_k8s apply -auto-approve \
               -var do_token=$DIGITAL_OCEAN_TOKEN \
-              -var cluster_name=$CLUSTER_NAME \
-              -var do_k8s_slug_ver=$DO_K8S_SLUG_VER
+              -var cluster_name=$CLUSTER_NAME
   
   deploy_to_k8s:
     docker:
@@ -204,8 +203,7 @@ jobs:
 
             terraform -chdir=./terraform/digital_ocean/do_create_k8s apply -destroy -auto-approve \
               -var do_token=$DIGITAL_OCEAN_TOKEN \
-              -var cluster_name=$CLUSTER_NAME \
-              -var do_k8s_slug_ver=$DO_K8S_SLUG_VER
+              -var cluster_name=$CLUSTER_NAME
 
   destroy_terraform_cloud:
     docker:

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ The project is a simple web application, that is packaged in a Docker container,
 
 ## Chapter 1 - Basics of CI/CD
 
-Most of our work will be in `./circleci/config.yml` - the CircleCI configuration file. This is where we will be describing our CI/CD pipelines.
+Most of our work will be in `.circleci/config.yml` - the CircleCI configuration file. This is where we will be describing our CI/CD pipelines.
 
 This workshop is written in chapters, so you can jump between them by running scripts in `scripts/` dir, if you get lost and want to catch up with something.
 To begin, prepare your environment for the initial state by running the start script: `./scripts/do_1_start.sh`
@@ -135,7 +135,7 @@ Navigate to the `Projects` tab, and find this workshop project there - `cicd-wor
 
 We will start off with a basic continuous integration pipeline, which will run your tests each time you commit some code. Run a commit for each instruction. The first pipeline is already configured, if it's not you can run: `./scripts/do_0_start.sh` to create the environment.
 
-Now review the `.circleci/config.yaml` find the `jobs` section, and a job called `build`, and workflow called `build_test_deploy`:
+Now review the `.circleci/config.yml` find the `jobs` section, and a job called `build`, and workflow called `build_test_deploy`:
 
 ```yaml
 version: 2.1

--- a/scripts/do/configs/config_2.yml
+++ b/scripts/do/configs/config_2.yml
@@ -40,7 +40,7 @@ jobs:
         - docker/push:
             image: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
             tag: 0.1.<< pipeline.number >>
-  
+
   dependency_vulnerability_scan:
     docker:
       - image: cimg/node:16.16.0
@@ -50,7 +50,7 @@ jobs:
       - snyk/scan:
           fail-on-issues: false
           monitor-on-build: false
-      
+
 workflows:
   test_scan_deploy:
     jobs:

--- a/scripts/do/configs/final.yml
+++ b/scripts/do/configs/final.yml
@@ -56,7 +56,7 @@ jobs:
         - docker/push:
             image: $DOCKER_LOGIN/$CIRCLE_PROJECT_REPONAME
             tag: 0.1.<< pipeline.number >>
-  
+
   dependency_vulnerability_scan:
     docker:
       - image: cimg/node:16.16.0
@@ -95,9 +95,8 @@ jobs:
             # Execute k8s creation
             terraform -chdir=terraform/digital_ocean/do_create_k8s apply -auto-approve \
               -var do_token=$DIGITAL_OCEAN_TOKEN \
-              -var cluster_name=$CLUSTER_NAME \
-              -var do_k8s_slug_ver=$DO_K8S_SLUG_VER
-  
+              -var cluster_name=$CLUSTER_NAME
+
   deploy_to_k8s:
     docker:
       - image: cimg/base:stable
@@ -127,7 +126,7 @@ jobs:
             terraform -chdir=terraform/digital_ocean/do_k8s_deploy_app init \
               -backend-config=remote_backend_config
 
-            # Execute apply comand 
+            # Execute apply command
             terraform -chdir=./terraform/digital_ocean/do_k8s_deploy_app apply -auto-approve \
               -var do_token=$DIGITAL_OCEAN_TOKEN \
               -var cluster_name=$CLUSTER_NAME \
@@ -141,7 +140,7 @@ jobs:
           root: /tmp/do_k8s/
           paths:
             - "*"
-    
+
   smoketest_k8s_deployment:
     docker:
       - image: cimg/base:stable
@@ -169,7 +168,7 @@ jobs:
             # Create backend file for terraform init with unique TF Cloud org for K8s cluster
             echo -en "organization = \"${TF_CLOUD_ORGANIZATION}\"\nworkspaces{name =\"${TF_CLOUD_WORKSPACE}\"}" > ./terraform/digital_ocean/do_create_k8s/remote_backend_config
             # Create backend file for terraform init with unique TF Cloud org K8s App Deploy
-            echo -en "organization = \"${TF_CLOUD_ORGANIZATION}\"\nworkspaces{name =\"${TF_CLOUD_WORKSPACE}-deployment\"}" > ./terraform/digital_ocean/do_k8s_deploy_app/remote_backend_config                        
+            echo -en "organization = \"${TF_CLOUD_ORGANIZATION}\"\nworkspaces{name =\"${TF_CLOUD_WORKSPACE}-deployment\"}" > ./terraform/digital_ocean/do_k8s_deploy_app/remote_backend_config
       - terraform/install:
           terraform_version: "1.2.0"
           arch: "amd64"
@@ -179,10 +178,10 @@ jobs:
           command: |
             export CLUSTER_NAME=${CIRCLE_PROJECT_USERNAME}-${CIRCLE_PROJECT_REPONAME}
             export TAG=0.1.<< pipeline.number >>
-            export DOCKER_IMAGE="${DOCKER_LOGIN}/${CIRCLE_PROJECT_REPONAME}:$TAG"          
+            export DOCKER_IMAGE="${DOCKER_LOGIN}/${CIRCLE_PROJECT_REPONAME}:$TAG"
             doctl auth init -t $DIGITAL_OCEAN_TOKEN
             doctl kubernetes cluster kubeconfig save $CLUSTER_NAME
-            
+
             # Initialize terraform with unique org name
             terraform -chdir=terraform/digital_ocean/do_k8s_deploy_app init \
               -backend-config=remote_backend_config
@@ -204,8 +203,7 @@ jobs:
 
             terraform -chdir=./terraform/digital_ocean/do_create_k8s apply -destroy -auto-approve \
               -var do_token=$DIGITAL_OCEAN_TOKEN \
-              -var cluster_name=$CLUSTER_NAME \
-              -var do_k8s_slug_ver=$DO_K8S_SLUG_VER
+              -var cluster_name=$CLUSTER_NAME
 
   destroy_terraform_cloud:
     docker:

--- a/scripts/do_1_start.sh
+++ b/scripts/do_1_start.sh
@@ -1,11 +1,8 @@
 #!/bin/bash
 
-rm -f .circleci/continue-config.yml
+test -f .circleci/continue-config.yml && rm .circleci/continue-config.yml
 
-# cp scripts/do/README.md .
-cp -f scripts/do/configs/config_1.yml .circleci/config.yml
+cp scripts/do/configs/config_1.yml .circleci/config.yml
 
 # Delete long running tests if they exist
 rm -f test/long-running-*.test.js
-
-

--- a/terraform/digital_ocean/do_create_k8s/main.tf
+++ b/terraform/digital_ocean/do_create_k8s/main.tf
@@ -28,11 +28,15 @@ provider "digitalocean" {
   token = var.do_token
 }
 
+# We like to live in the edge.
+data "digitalocean_kubernetes_versions" "latest" {}
+
 resource "digitalocean_kubernetes_cluster" "k8s_cluster" {
   name   = var.cluster_name
   region = var.do_data_center
-  # Grab the latest version slug from `doctl kubernetes options versions`
-  version = var.do_k8s_slug_ver
+  # HINT: If this breaks, you can use `var.do_k8s_slug_ver`, but uncomment it
+  #       on `variables.tf` file in this directory.
+  version = data.digitalocean_kubernetes_versions.latest.latest_version
 
   node_pool {
     name       = var.cluster_name

--- a/terraform/digital_ocean/do_create_k8s/variables.tf
+++ b/terraform/digital_ocean/do_create_k8s/variables.tf
@@ -18,7 +18,7 @@ variable "cluster_name" {
   }  
 }
 
-variable "do_k8s_slug_ver" {
-  type = string
-  description = "DO Kubernetes version slug. Get it using this: doctl kubernetes options versions"
-}
+#variable "do_k8s_slug_ver" {
+#  type = string
+#  description = "DO Kubernetes version slug. Get it using this: doctl kubernetes options versions"
+#}


### PR DESCRIPTION
On `README.md` file, we fix the Circle CI main config file path.

On `scripts/do_1_starth.sh`, removing the 'force' options, as it can
potentially masks whether the script runs its commands successfully
or not.

On the Kubernetes cluster setup step, we can actually fetch the
latest K8S version by using the `datasource` to query the latest version.

Finally, removing whitespaces to reduce the noise when doing `git diff`.